### PR TITLE
unwindpmp: Add the ability to trace threads individually.

### DIFF
--- a/src/tracer/dw_tracer.h
+++ b/src/tracer/dw_tracer.h
@@ -22,7 +22,7 @@ struct DwTracer : UwpmpTracer {
   ~DwTracer();
   static int frame_cb(Dwfl_Frame* state, void* arg);
  
-  int trace(std::shared_ptr<UwpmpThread> t);
-  int trace_all();
+  int trace_tid(pid_t pid, std::string name);
+  int trace(pid_t pid);
 };
 #endif

--- a/src/tracer/unwind_tracer.h
+++ b/src/tracer/unwind_tracer.h
@@ -14,7 +14,6 @@ struct UnwindTracer : UwpmpTracer {
     unw_set_caching_policy(as, UNW_CACHE_GLOBAL);
     unw_set_cache_size(as, 1024, 0);
   }
-  int trace(std::shared_ptr<UwpmpThread> t); 
-  int trace_all();
+  int trace_tid(pid_t pid, std::string name);
 };
 #endif

--- a/src/tracer/uwpmp_tracer.cc
+++ b/src/tracer/uwpmp_tracer.cc
@@ -1,5 +1,9 @@
 #include <cxxabi.h>
+#include <dirent.h>
+#include <fstream>
 #include <string>
+#include <stdexcept>
+#include <sys/stat.h>
 #include "uwpmp_tracer.h"
 #include "unwind_tracer.h"
 #include "dw_tracer.h"
@@ -29,4 +33,85 @@ std::string UwpmpTracer::demangle(const char *sym) {
   }
   std::free(demangled);
   return namestr;
+}
+
+bool UwpmpTracer::is_process(pid_t pid) {
+  pid_t tgid = 0;
+
+  // check /proc/<PID>/status to see if the Tgid is the same as the pid 
+  std::string status_file = "/proc/" + std::to_string(pid) + "/status";
+  std::ifstream input(status_file, std::ios::in | std::ios::binary);
+  if (input) {
+    // Read the file into a string safely via iterators (can still truncate)
+    std::string s((std::istreambuf_iterator<char>(input)),
+                   std::istreambuf_iterator<char>());
+    std::istringstream iss(s);
+    for (std::string line; std::getline(iss, line); ) {
+      if (line.rfind("Tgid:", 0) != 0) {
+        continue;
+      }
+      auto start = s.find('\t');
+      if (start < std::string::npos) {
+        start = start + 1;
+      }
+      auto end = line.length();
+      if (start >= end) {
+        break;
+      }
+      std::string tgid_str = line.substr(start, end);
+
+      try {
+        tgid = (pid_t) stoi(tgid_str);
+      }
+      catch(const std::exception& e) {
+        std::cout << "stoi conversion failed: " << e.what() << std::endl;
+        break;
+      }
+      // trace all threads if a process, otherwise only the thread
+      if (pid == tgid) {
+        return true;
+      }
+      return false;
+    }
+  }
+  throw std::runtime_error("PID " + std::to_string(pid) + " not found"); 
+}
+
+int UwpmpTracer::trace_one(pid_t tid, std::string proc_comm)
+{
+  struct stat buf;
+  if (stat(proc_comm.c_str(), &buf) == 0) {
+    std::ifstream is(proc_comm);
+    std::string name;
+    std::getline(is, name);
+    is.close();
+    trace_tid(tid, name);
+  }
+  return 0;
+}
+
+int UwpmpTracer::trace_all(pid_t pid)
+{
+  std::string proc_tasks = "/proc/" + std::to_string(pid) + "/task";
+  DIR *dir;
+  struct dirent *ent;
+  if ((dir = opendir (proc_tasks.c_str())) != nullptr) {
+    while ((ent = readdir (dir)) != NULL) {
+      char *endptr;
+      int tid = strtol(ent->d_name, &endptr, 10);
+      if (*endptr == '\0') {
+        trace_one((pid_t) tid, proc_tasks + "/" + std::to_string(tid) + "/comm");
+      }
+    }
+  }
+  return 0;
+}
+
+int UwpmpTracer::trace(pid_t pid)
+{
+  if (is_process(pid)) {
+    return trace_all(pid);
+  }
+  auto pid_str = std::to_string(pid);
+  return trace_one(pid, "/proc/" + pid_str + "/task/" + pid_str + "/comm");
 }

--- a/src/tracer/uwpmp_tracer.h
+++ b/src/tracer/uwpmp_tracer.h
@@ -10,9 +10,12 @@ enum TracerType {
 };
 
 struct UwpmpTracer {
+  virtual int trace_tid(pid_t pid, std::string name) = 0;
   static std::string demangle(const char *sym);
-  virtual int trace(std::shared_ptr<UwpmpThread> t) = 0;
-  virtual int trace_all() = 0;
+  virtual bool is_process(pid_t pid);
+  virtual int trace_one(pid_t pid, std::string proc_comm);
+  virtual int trace_all(pid_t pid);
+  virtual int trace(pid_t pid);
 };
 
 struct UwpmpTracerFactory {

--- a/src/unwindpmp.cc
+++ b/src/unwindpmp.cc
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
   }
   for (int i = 0; i < ctx.samples; i++) {
     std::cout << "sample: " << i << std::endl;
-    tracer->trace_all();
+    tracer->trace((pid_t) ctx.pid);
   }
   auto thread_vec = thf.sorted_getall();
   for (auto thread : thread_vec) {

--- a/src/uwpmp_types.h
+++ b/src/uwpmp_types.h
@@ -12,7 +12,7 @@
 #include "cxxopts.hpp"
 
 struct UwpmpCtx {
-  pid_t pid;                         // required, must attach to process
+  pid_t pid;                         // required, attach to process or thread
   uint32_t sleep = 0;                // optional, default 0ms
   uint32_t samples = 100;            // optional, default 1000 samples
   float threshold = 0.1;             // optional, default to 0.1%
@@ -31,7 +31,7 @@ struct UwpmpCtx {
         .add_options()
         ("h, help", "show this help message and exit")
 //        ("i, input", "Read collected samples from this file.", cxxopts::value<std::string>())
-        ("p, pid", "PID of the process to attach to.", cxxopts::value<uint32_t>())
+        ("p, pid", "PID of the process or thread to attach to.", cxxopts::value<uint32_t>())
         ("s, sleep", "The time to sleep between samples in ms.", cxxopts::value<uint32_t>())
         ("n, samples", "The number of samples to collect.", cxxopts::value<uint32_t>())
 //        ("o, output", "Write collected samples to this file.", cxxopts::value<std::string())
@@ -140,7 +140,7 @@ struct UwpmpThreadFactory {
 
   UwpmpThreadFactory(UwpmpCtx *c) : ctx(c), thread_map{} {}
 
-  std::shared_ptr<UwpmpThread> get(std::string name, pid_t tid) {
+  std::shared_ptr<UwpmpThread> get(pid_t tid, std::string name) {
     std::string key = name + std::to_string(tid);
     auto thread = std::make_shared<UwpmpThread>(ctx, name, tid);
     thread_map.try_emplace(key, thread);


### PR DESCRIPTION
This lets us trace threads individually rather than tracing the application as a whole.  Much faster if you are only interested in a single thread.

brave browser process (34 threads):
```
$ time sudo ./unwindpmp -n 100 -p 6258
...
real	0m34.377s
user	0m0.006s
sys	0m0.003s
```

thread:
```
$ time sudo ./unwindpmp -n 100 -p 6300
...
real	0m1.590s
user	0m0.002s
sys	0m0.004s
```