### PR TITLE
containerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM quay.io/centos/centos:stream9
 
 RUN dnf install -y \
       elfutils-libs \
+      procps-ng \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+#syntax=docker/dockerfile:1
+
+FROM quay.io/centos/centos:stream9 AS builder
+
+RUN dnf install -y \
+      git \
+      cmake \
+      gcc-c++ \
+      elfutils-libelf-devel \
+      elfutils-devel \
+      autoconf \
+      automake \
+      libtool \
+    && dnf clean all
+
+COPY . /tmp/uwpmp
+
+RUN cd /tmp/uwpmp \
+    && rm -rf build \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && make -j $(nproc)
+
+FROM quay.io/centos/centos:stream9
+
+RUN dnf install -y \
+      elfutils-libs \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+COPY --from=builder /tmp/uwpmp/build/unwindpmp /usr/local/bin/unwindpmp

--- a/README.md
+++ b/README.md
@@ -68,3 +68,27 @@ Usage:
   -r, --truncate       Truncate lines to the terminal width
 ```
 
+### Container
+
+#### Build
+docker build -t uwpmp .
+
+#### Run — attach to host OSD
+docker run -it --rm \
+  --pid=host \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  --security-opt apparmor=unconfined \
+  uwpmp \
+  unwindpmp -p <osd-pid> -n 1000 -s 10
+
+Or drop into a shell first:
+
+docker run -it --rm \
+  --pid=host \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  --security-opt apparmor=unconfined \
+  uwpmp \
+  bash
+

--- a/src/tracer/unwind_tracer.cc
+++ b/src/tracer/unwind_tracer.cc
@@ -1,3 +1,5 @@
+#include <cerrno>
+#include <cstring>
 #include <dirent.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
@@ -10,7 +12,7 @@ int UnwindTracer::trace_tid(pid_t pid, std::string name)
   std::vector<std::string> frames;
 
   if (ptrace(PTRACE_ATTACH, t->id, 0, 0) != 0) {
-    die("ERROR: cannot attach to %d\n", t->id);
+    die("ERROR: cannot attach to %d: %s\n", t->id, strerror(errno));
   }
   waitpid(t->id, NULL, 0);
 


### PR DESCRIPTION
```
  --pid=host \
  --cap-add=SYS_PTRACE \
  --security-opt seccomp=unconfined \
  --security-opt apparmor=unconfined \
```

  --pid=host  let's you see same PIDs as if you were on the host, 
  
```
    --cap-add=SYS_PTRACE \
  --security-opt seccomp=unconfined \
  --security-opt apparmor=unconfined \
```
  
  these other flags, I found by experimenting. It is similar to what kubectl debug mounts with to allow tracing. Specifically need --security-opt apparmor=unconfined for OSDs. 