### PR TITLE
Tracer: Fix libdw cache bug, missing include for Ubuntu

### DIFF
--- a/src/tracer/dw_tracer.cc
+++ b/src/tracer/dw_tracer.cc
@@ -54,23 +54,19 @@ int DwTracer::frame_cb(Dwfl_Frame* state, void* arg)
   Dwfl* dwfl = dwfl_thread_dwfl(thread);
   Dwfl_Module* module = dwfl_addrmodule(dwfl, pc);
 
-  if (module != NULL) {
-    std::string key(reinterpret_cast<char*>(module));
-    key += pc;
-    auto it = dw_ctx->modcache.find(key);
-    if (it != dw_ctx->modcache.end()) {
+  auto it = dw_ctx->modcache.find(pc);
+  if (it != dw_ctx->modcache.end()) {
       dw_ctx->cur_frames.emplace_back(it->second);
       dw_ctx->cache_hits++;
       return DWARF_CB_OK;
-    }
+  }
 
-//    const char *modname = NULL;
-		const char *symname = NULL;
+  if (module != NULL) {
+    const char *symname = NULL;
     GElf_Off off = 0;
     GElf_Sym sym;
-//    modname = dwfl_module_info(module, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     symname = dwfl_module_addrinfo(module, pc, &off, &sym, NULL, NULL, NULL); 
-    dw_ctx->modcache.emplace(key, demangle(symname));
+    dw_ctx->modcache.emplace(pc, demangle(symname));
     dw_ctx->cur_frames.emplace_back(demangle(symname));
     dw_ctx->cache_misses++;
   }

--- a/src/tracer/dw_tracer.h
+++ b/src/tracer/dw_tracer.h
@@ -8,7 +8,7 @@ struct DwTracer : UwpmpTracer {
   struct DwTracerCtx {
     DwTracerCtx() : cur_frames(), modcache(), cache_hits(0), cache_misses(0) {}
     std::vector<std::string> cur_frames;
-    std::unordered_map<std::string, std::string> modcache;
+    std::unordered_map<Dwarf_Addr, std::string> modcache;
     uint64_t cache_hits;
     uint64_t cache_misses;
   };

--- a/src/uwpmp_types.h
+++ b/src/uwpmp_types.h
@@ -3,6 +3,7 @@
 #define UWPMP_TYPES_H
 
 #include <cstdlib>
+#include <cstdint>
 #include <iostream>
 #include <iomanip>
 #include <string>


### PR DESCRIPTION
Two fixes, one for a longstanding libdw cache bug.  The other for a missing include that primarily affects ubuntu.